### PR TITLE
[Fix #71] Update discussion board link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,6 @@ The `AUTORELEASE_ARTIFACT` and `SKIP_JAR_DEPLOYMENT` variables expect boolean va
 
 ### Contact Information
 
-If you notice something that is broken or that needs fixing, please submit a ticket to the project's [issues queue](https://github.com/ksclarke/freelib-build-tools/issues). If you have a question or a general comment about the project, please use the project's [discussion board](https://github.com/ksclarke/jiiify-presentation/discussions).
+If you notice something that is broken or that needs fixing, please submit a ticket to the project's [issues queue](https://github.com/ksclarke/freelib-build-tools/issues). If you have a question or a general comment about the project, please use the project's [discussion board](https://github.com/ksclarke/freelib-build-tools/discussions).
 
 Thanks for your interest in this project!


### PR DESCRIPTION
This was a copy and paste error.